### PR TITLE
Fix syntax error in table_log_pl_init

### DIFF
--- a/sql/table_log_pl--0.1.sql
+++ b/sql/table_log_pl--0.1.sql
@@ -342,7 +342,7 @@ RETURNS void AS
 $BODY$
 DECLARE
     do_log_user  int = 0;
-    level_create text = E'''';
+    level_create text = E'';
     orig_qq      text;
     log_qq       text;
 BEGIN

--- a/sql/table_log_pl_init.sql
+++ b/sql/table_log_pl_init.sql
@@ -5,7 +5,7 @@ RETURNS void AS
 $BODY$
 DECLARE
     do_log_user  int = 0;
-    level_create text = E'''';
+    level_create text = E'';
     orig_qq      text;
     log_qq       text;
 BEGIN


### PR DESCRIPTION
table_log_pl_init had an unbalanced apostrophe in the dynamic SQL
it generated, in all versions tested and regardless of the value
of standard_conforming_strings.